### PR TITLE
equals(Object obj)" and "hashCode()" should be overridden in pairs

### DIFF
--- a/src/main/java/redress/memory/address/AbstractAddress.java
+++ b/src/main/java/redress/memory/address/AbstractAddress.java
@@ -8,6 +8,7 @@ import redress.memory.data.QWord;
 import redress.util.B;
 
 import java.nio.ByteOrder;
+import java.util.Arrays;
 
 /**
  * Created by jamesrichardson on 2/11/16.
@@ -120,6 +121,14 @@ public abstract class AbstractAddress implements IContainer,Comparable<AbstractA
             }
         }
         return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = this.BYTES;
+        result = 31 * result + (this.BYTEORDER != null ? this.BYTEORDER.hashCode() : 0);
+        result = 31 * result + Arrays.hashCode(this.container);
+        return result;
     }
 
     @Override

--- a/src/main/java/redress/memory/data/AbstractData.java
+++ b/src/main/java/redress/memory/data/AbstractData.java
@@ -9,6 +9,7 @@ import redress.util.B;
 
 import java.math.BigInteger;
 import java.nio.ByteOrder;
+import java.util.Arrays;
 import java.util.HashSet;
 
 /**
@@ -175,6 +176,22 @@ public abstract class AbstractData implements IContainer, IAddressable{
         if(!(o instanceof AbstractData))
             return false;
         return equals((AbstractData) o, false);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = this.parent != null ? this.parent.hashCode() : 0;
+        result = 31 * result + (this.previousSibling != null ? this.previousSibling.hashCode() : 0);
+        result = 31 * result + (this.nextSibling != null ? this.nextSibling.hashCode() : 0);
+        result = 31 * result + (this.beginAddress != null ? this.beginAddress.hashCode() : 0);
+        result = 31 * result + (this.endAddress != null ? this.endAddress.hashCode() : 0);
+        result = 31 * result + Arrays.hashCode(this.container);
+        result = 31 * result + (this.BYTEORDER != null ? this.BYTEORDER.hashCode() : 0);
+        result = 31 * result + this.BYTES;
+        result = 31 * result + (this.userData != null ? this.userData.hashCode() : 0);
+        result = 31 * result + (this.type != null ? this.type.hashCode() : 0);
+        result = 31 * result + (this.comment != null ? this.comment.hashCode() : 0);
+        return result;
     }
 
     public boolean and(IContainer in){


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1206 - “equals(Object obj)" and "hashCode()" should be overridden in pairs ”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1206
Please let me know if you have any questions.
Ayman Abdelghany.
